### PR TITLE
不要なデバッグログを削除、検出画像のはみだしを制御

### DIFF
--- a/lib/data/datasource/database/railway_database_service.dart
+++ b/lib/data/datasource/database/railway_database_service.dart
@@ -115,7 +115,6 @@ class RailwayDatabaseService {
           : null,
     };
 
-    debugPrint('Converted to model map: $modelMap');
     return modelMap;
   }
 

--- a/lib/ui/core/detection_dialog.dart
+++ b/lib/ui/core/detection_dialog.dart
@@ -41,6 +41,7 @@ class DetectionResultDialog extends StatelessWidget {
                     child: Image.memory(
                       result.croppedimage!,
                       height: 100,
+                      width: 100,
                       fit: BoxFit.cover,
                     ),
                   ),

--- a/lib/ui/realtime_detection/realtime_detection_screen.dart
+++ b/lib/ui/realtime_detection/realtime_detection_screen.dart
@@ -32,20 +32,13 @@ class _RealtimeDetectionScreenState
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('リアルタイムメトロ検出'),
+        title: const Text('路線ロゴ検出'),
         backgroundColor: Colors.lightBlueAccent,
         titleTextStyle: const TextStyle(
           color: Colors.white,
           fontSize: 20,
           fontWeight: FontWeight.bold,
         ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh_rounded),
-            // モデルの再読み込み
-            onPressed: () {},
-          ),
-        ],
       ),
       body: Stack(
         children: [

--- a/lib/ui/realtime_detection/realtime_detection_viewmodel.dart
+++ b/lib/ui/realtime_detection/realtime_detection_viewmodel.dart
@@ -10,7 +10,6 @@ import 'package:train_logo_detection_app/data/repositories/google_ocr_image.dart
 import 'package:train_logo_detection_app/domain/models/logo_detection/train_logo_detection.dart';
 import 'package:train_logo_detection_app/domain/usecase/verify_detected_object.dart';
 
-
 final realtimeDetectionViewmodelProvider =
     ChangeNotifierProvider((ref) => RealtimeDetectionViewmodel());
 

--- a/lib/ui/station_detail/station_detail_screen.dart
+++ b/lib/ui/station_detail/station_detail_screen.dart
@@ -25,10 +25,11 @@ class _StationDetailScreenState extends ConsumerState<StationDetailScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            Text(widget.station.title),
             const Icon(Icons.train_outlined, color: Colors.white),
             const SizedBox(width: 8),
-            Text(widget.station.title),
           ],
         ),
         backgroundColor: Colors.lightBlueAccent,

--- a/lib/ui/station_detail/station_detail_screen.dart
+++ b/lib/ui/station_detail/station_detail_screen.dart
@@ -24,7 +24,13 @@ class _StationDetailScreenState extends ConsumerState<StationDetailScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.station.title),
+        title: Row(
+          children: [
+            const Icon(Icons.train_outlined, color: Colors.white),
+            const SizedBox(width: 8),
+            Text(widget.station.title),
+          ],
+        ),
         backgroundColor: Colors.lightBlueAccent,
       ),
       body: SingleChildScrollView(


### PR DESCRIPTION
- 検出画像がはみ出るケースがあるので、それをサイズ指定することで応急処置